### PR TITLE
Fix provision cleanup after context cancellation

### DIFF
--- a/provision/provision.go
+++ b/provision/provision.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	AgentUid  uint32 = 1100
-	AgentGid  uint32 = 1100
-	AgentUser        = "agent"
+	AgentUid                uint32 = 1100
+	AgentGid                uint32 = 1100
+	AgentUser                      = "agent"
+	builderCleanupOpTimeout        = 2 * time.Minute
 )
 
 type Config struct {
@@ -37,6 +38,13 @@ type Config struct {
 
 //go:embed run_agent.sh
 var runAgentScript string
+
+func waitCleanupOp(ctx context.Context, op incus.Operation) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), builderCleanupOpTimeout)
+	defer cancel()
+
+	return op.WaitContext(cleanupCtx)
+}
 
 func BaseImage(ctx context.Context, c incus.InstanceServer, conf Config) error {
 	if conf.ProjectName != "" {
@@ -84,6 +92,29 @@ func BaseImage(ctx context.Context, c incus.InstanceServer, conf Config) error {
 	if err = op.WaitContext(ctx); err != nil {
 		return err
 	}
+
+	// Ensure the builder instance is cleaned up on any subsequent failure.
+	defer func() {
+		stopOp, err := c.UpdateInstanceState(req.Name, api.InstanceStatePut{
+			Action:  "stop",
+			Force:   true,
+			Timeout: -1,
+		}, "")
+		if err == nil {
+			if err := waitCleanupOp(ctx, stopOp); err != nil {
+				slog.Error("error stopping builder instance", "instance", req.Name, "err", err)
+			}
+		}
+
+		delOp, err := c.DeleteInstance(req.Name)
+		if err != nil {
+			slog.Error("error deleting", "instance", req.Name, "err", err)
+			return
+		}
+		if err = waitCleanupOp(ctx, delOp); err != nil {
+			slog.Error("error deleting", "instance", req.Name, "err", err)
+		}
+	}()
 
 	i, etag, err := c.GetInstance(req.Name)
 	if err != nil {
@@ -200,21 +231,6 @@ su - "${AGENT_USER}" -c "
 	if err := op.WaitContext(ctx); err != nil {
 		return err
 	}
-
-	defer func() {
-
-		op, err := c.DeleteInstance(i.Name)
-		if err != nil {
-			slog.Error("error deleting", "instance", i.Name, "err", err)
-			return
-		}
-
-		if err = op.WaitContext(ctx); err != nil {
-			slog.Error("error deleting", "instance", i.Name, "err", err)
-			return
-		}
-
-	}()
 
 	// Publish the image
 	slog.Info("publishing image", "instance", i.Name, "target", conf.TargetAlias)

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -1,9 +1,13 @@
 package provision
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/sklarsa/incus-azure-pipelines/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,4 +37,35 @@ func TestRandomString(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEqual(t, a, b)
 	})
+}
+
+func TestWaitCleanupOpIgnoresParentCancellation(t *testing.T) {
+	type ctxKey string
+
+	const key ctxKey = "key"
+
+	parentCtx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "value"))
+	cancel()
+
+	op := mocks.NewMockOperation(t)
+	op.On("WaitContext", mock.MatchedBy(func(ctx context.Context) bool {
+		if got := ctx.Value(key); got != "value" {
+			return false
+		}
+
+		if ctx.Err() != nil {
+			return false
+		}
+
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return false
+		}
+
+		remaining := time.Until(deadline)
+		return remaining > 0 && remaining <= builderCleanupOpTimeout
+	})).Return(nil).Once()
+
+	err := waitCleanupOp(parentCtx, op)
+	require.NoError(t, err)
 }

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -39,6 +39,9 @@ func TestRandomString(t *testing.T) {
 	})
 }
 
+// TestWaitCleanupOpIgnoresParentCancellation covers the deferred cleanup path in
+// BaseImage, where teardown must still wait for stop/delete operations after the
+// main request context has already been canceled.
 func TestWaitCleanupOpIgnoresParentCancellation(t *testing.T) {
 	type ctxKey string
 


### PR DESCRIPTION
## Summary
- move builder cleanup to run from immediately after instance creation so early provisioning failures are covered
- wait for deferred stop/delete operations with a bounded context that ignores parent cancellation
- add a regression test documenting why cleanup must survive request cancellation

## Testing
- go test ./provision
- go test ./...