### PR TITLE
Move config defaults to definition sites

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"time"
+	"fmt"
 
+	"github.com/creasty/defaults"
 	"github.com/go-playground/validator/v10"
 	"github.com/goccy/go-yaml"
 	"github.com/sklarsa/incus-azure-pipelines/daemon"
@@ -14,22 +15,15 @@ type CLIConfig struct {
 	// Pools is the list of agent pools to manage.
 	Pools []pool.Config `json:"pools,omitempty" validate:"unique=Name,dive"`
 	// MetricsPort is the port number that serves Prometheus metrics. Default: 9922
-	MetricsPort int `json:"metricsPort,omitempty" validate:"min=0"`
+	MetricsPort int `json:"metricsPort,omitempty" validate:"min=0" default:"9922"`
 	// Daemon contains settings for the background daemon processes.
 	Daemon daemon.Config `json:"daemon,omitempty"`
 }
 
 func parseConfig(data []byte) (CLIConfig, error) {
-	config := CLIConfig{
-		MetricsPort: 9922,
-		Daemon: daemon.Config{
-			ReconcileInterval: 5 * time.Second,
-			ReaperInterval:    30 * time.Second,
-			Listener: daemon.ListenerConfig{
-				RetryDelay:    1 * time.Second,
-				MaxRetryDelay: 1 * time.Minute,
-			},
-		},
+	config := CLIConfig{}
+	if err := defaults.Set(&config); err != nil {
+		return config, fmt.Errorf("error setting defaults: %w", err)
 	}
 
 	if err := yaml.Unmarshal(data, &config); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -13,9 +13,9 @@ import (
 // Config contains settings for daemon background processes.
 type Config struct {
 	// ReaperInterval is how often to check for and clean up stale agents. Default: 30s
-	ReaperInterval time.Duration `json:"reaperInterval,omitempty"`
+	ReaperInterval time.Duration `json:"reaperInterval,omitempty" default:"30s"`
 	// ReconcileInterval is how often to reconcile expected vs actual agent count. Default: 5s
-	ReconcileInterval time.Duration `json:"reconcileInterval,omitempty"`
+	ReconcileInterval time.Duration `json:"reconcileInterval,omitempty" default:"5s"`
 	// Listener contains settings for the event listener.
 	Listener ListenerConfig `json:"listener,omitempty"`
 }
@@ -23,9 +23,9 @@ type Config struct {
 // ListenerConfig contains settings for event listener retry behavior.
 type ListenerConfig struct {
 	// RetryDelay is the initial delay between retries. Default: 1s
-	RetryDelay time.Duration `json:"retryDelay,omitempty"`
+	RetryDelay time.Duration `json:"retryDelay,omitempty" default:"1s"`
 	// MaxRetryDelay is the maximum delay between retries. Default: 1m
-	MaxRetryDelay time.Duration `json:"maxRetryDelay,omitempty"`
+	MaxRetryDelay time.Duration `json:"maxRetryDelay,omitempty" default:"1m"`
 }
 
 func Run(ctx context.Context, p *pool.Pool, conf Config) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.4
 
 require (
 	github.com/avast/retry-go/v4 v4.7.0
+	github.com/creasty/defaults v1.8.0
 	github.com/go-playground/validator/v10 v10.28.0
 	github.com/goccy/go-yaml v1.19.0
 	github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7np
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creasty/defaults v1.8.0 h1:z27FJxCAa0JKt3utc0sCImAEb+spPucmKoOdLHvHYKk=
+github.com/creasty/defaults v1.8.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- move config defaults onto struct fields at their definition sites
- apply defaults once during config parsing and return setup errors if defaulting fails
- add github.com/creasty/defaults as a direct dependency

## Testing
- go test ./...