### PR TITLE
fix: fail the build when a provisioning script exits non-zero

### DIFF
--- a/provision/provision.go
+++ b/provision/provision.go
@@ -56,6 +56,28 @@ func waitCleanupOp(ctx context.Context, op incus.Operation) error {
 	return op.WaitContext(cleanupCtx)
 }
 
+// checkExecExit waits for an exec operation and returns an error if the executed
+// command exited non-zero. op.WaitContext only fails when the *operation* fails,
+// not when the command itself exits non-zero — so without this, a failed
+// provisioning step would be ignored and a broken image published anyway.
+func checkExecExit(ctx context.Context, op incus.Operation, desc string) error {
+	if err := op.WaitContext(ctx); err != nil {
+		return fmt.Errorf("error executing %s: %w", desc, err)
+	}
+	meta := op.Get().Metadata
+	if meta == nil {
+		return fmt.Errorf("error executing %s: no operation metadata", desc)
+	}
+	ret, ok := meta["return"].(float64)
+	if !ok {
+		return fmt.Errorf("error executing %s: could not determine exit code", desc)
+	}
+	if int(ret) != 0 {
+		return fmt.Errorf("%s exited with code %d", desc, int(ret))
+	}
+	return nil
+}
+
 func BaseImage(ctx context.Context, c incus.InstanceServer, conf Config) error {
 	if conf.ProjectName != "" {
 		c = c.UseProject(conf.ProjectName)
@@ -200,8 +222,7 @@ su - "${AGENT_USER}" -c "
 	if err != nil {
 		return err
 	}
-
-	if err := op.WaitContext(ctx); err != nil {
+	if err := checkExecExit(ctx, op, "base provisioning"); err != nil {
 		return err
 	}
 
@@ -231,9 +252,8 @@ su - "${AGENT_USER}" -c "
 		if err != nil {
 			return fmt.Errorf("error executing script %s: %w", conf.Scripts[idx], err)
 		}
-
-		if err := op.WaitContext(ctx); err != nil {
-			return fmt.Errorf("error executing script %s: %w", conf.Scripts[idx], err)
+		if err := checkExecExit(ctx, op, fmt.Sprintf("script %s", conf.Scripts[idx])); err != nil {
+			return err
 		}
 
 	}

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -5,11 +5,39 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lxc/incus/v6/shared/api"
 	"github.com/sklarsa/incus-azure-pipelines/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCheckExecExit(t *testing.T) {
+	t.Run("zero exit passes", func(t *testing.T) {
+		op := mocks.NewMockOperation(t)
+		op.On("WaitContext", mock.Anything).Return(nil)
+		op.On("Get").Return(api.Operation{Metadata: map[string]any{"return": float64(0)}})
+		require.NoError(t, checkExecExit(context.Background(), op, "test step"))
+	})
+
+	t.Run("non-zero exit returns an error", func(t *testing.T) {
+		op := mocks.NewMockOperation(t)
+		op.On("WaitContext", mock.Anything).Return(nil)
+		op.On("Get").Return(api.Operation{Metadata: map[string]any{"return": float64(2)}})
+		err := checkExecExit(context.Background(), op, "test step")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "test step exited with code 2")
+	})
+
+	t.Run("missing return code is an error", func(t *testing.T) {
+		op := mocks.NewMockOperation(t)
+		op.On("WaitContext", mock.Anything).Return(nil)
+		op.On("Get").Return(api.Operation{Metadata: map[string]any{}})
+		err := checkExecExit(context.Background(), op, "test step")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not determine exit code")
+	})
+}
 
 func TestInstanceTypeStr(t *testing.T) {
 	assert.Equal(t, "container", instanceTypeStr(false))


### PR DESCRIPTION
## Problem

`BaseImage` runs the base provisioning and each custom `--scripts` step via
`ExecInstance` + `op.WaitContext`. But `WaitContext` only returns an error when the
Incus **operation** fails — **not** when the executed command exits non-zero. So a
provisioning script that fails partway (e.g. a `set -e` abort) is silently ignored
and the half-built image is published anyway, missing everything after the failure.

This bit us: an agent image shipped without `go`/`kind`/`helm` because a checksum
step failed mid-script — with no error surfaced.

## Fix

Add `checkExecExit`, which waits for the exec op and then inspects the command's
exit code from the operation metadata (`return`), returning an error if it's
non-zero. Use it for both the base provisioning exec and each custom script exec, so
`provision` aborts loudly instead of publishing a broken image.

Unit tests cover the zero-exit, non-zero-exit, and missing-return-code cases. Build
+ `go vet` + full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)