### PR TITLE
fix: don't log spurious error when builder is already stopped

### DIFF
--- a/provision/provision.go
+++ b/provision/provision.go
@@ -49,6 +49,15 @@ func instanceTypeStr(vm bool) string {
 //go:embed run_agent.sh
 var runAgentScript string
 
+// isAlreadyStopped reports whether err is the Incus "instance is already
+// stopped" response. Incus returns this as a 400 Bad Request with that
+// message; there is no exported sentinel in the client package, so we match
+// on the status and message.
+func isAlreadyStopped(err error) bool {
+	return api.StatusErrorCheck(err, http.StatusBadRequest) &&
+		strings.Contains(err.Error(), "already stopped")
+}
+
 func waitCleanupOp(ctx context.Context, op incus.Operation) error {
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), builderCleanupOpTimeout)
 	defer cancel()
@@ -132,10 +141,16 @@ func BaseImage(ctx context.Context, c incus.InstanceServer, conf Config) error {
 			Force:   true,
 			Timeout: -1,
 		}, "")
-		if err == nil {
-			if err := waitCleanupOp(ctx, stopOp); err != nil {
+		// On the success path the instance is already stopped before publish,
+		// so this stop is expected to be a no-op. Incus reports that as a
+		// 400 "instance is already stopped" — treat it as success rather than
+		// logging a spurious error.
+		if err != nil {
+			if !isAlreadyStopped(err) {
 				slog.Error("error stopping builder instance", "instance", req.Name, "err", err)
 			}
+		} else if err := waitCleanupOp(ctx, stopOp); err != nil {
+			slog.Error("error stopping builder instance", "instance", req.Name, "err", err)
 		}
 
 		delOp, err := c.DeleteInstance(req.Name)


### PR DESCRIPTION
## Summary
On the success path the builder instance is gracefully stopped before publishing the image. The deferred cleanup then issues a force-stop on every return path, which on the success path hits an already-stopped instance — Incus returns a `400 "The instance is already stopped"`.

This surfaced as a confusing `error stopping builder instance` log line on otherwise-successful builds.

## Changes
- Add an `isAlreadyStopped` helper that matches the Incus 400 "already stopped" response.
- In the deferred cleanup, treat that response as a no-op rather than logging it as an error.

## Notes
This is the "instance is already stopped" error reported during builds. It was non-fatal (logged, not returned), so builds still succeeded — this just removes the misleading error log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)