### PR TITLE
fix: ignore already-stopped error from the cleanup stop operation

### DIFF
--- a/provision/provision.go
+++ b/provision/provision.go
@@ -66,6 +66,33 @@ func waitCleanupOp(ctx context.Context, op incus.Operation) error {
 	return op.WaitContext(cleanupCtx)
 }
 
+// stopBuilderForCleanup force-stops the builder instance during cleanup. On the
+// success path the instance is already stopped before publishing, so this is a
+// no-op; Incus reports that as a 400 "instance is already stopped" either
+// synchronously or via the returned operation. Both forms are treated as
+// success so they don't surface as spurious errors.
+func stopBuilderForCleanup(ctx context.Context, c incus.InstanceServer, name string) error {
+	op, err := c.UpdateInstanceState(name, api.InstanceStatePut{
+		Action:  "stop",
+		Force:   true,
+		Timeout: -1,
+	}, "")
+	if err != nil {
+		if isAlreadyStopped(err) {
+			return nil
+		}
+		return err
+	}
+
+	if err := waitCleanupOp(ctx, op); err != nil {
+		if isAlreadyStopped(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 // checkExecExit waits for an exec operation and returns an error if the executed
 // command exited non-zero. op.WaitContext only fails when the *operation* fails,
 // not when the command itself exits non-zero — so without this, a failed
@@ -137,20 +164,7 @@ func BaseImage(ctx context.Context, c incus.InstanceServer, conf Config) error {
 
 	// Ensure the builder instance is cleaned up on any subsequent failure.
 	defer func() {
-		stopOp, err := c.UpdateInstanceState(req.Name, api.InstanceStatePut{
-			Action:  "stop",
-			Force:   true,
-			Timeout: -1,
-		}, "")
-		// On the success path the instance is already stopped before publish,
-		// so this stop is expected to be a no-op. Incus reports that as a
-		// 400 "instance is already stopped" — treat it as success rather than
-		// logging a spurious error.
-		if err != nil {
-			if !isAlreadyStopped(err) {
-				slog.Error("error stopping builder instance", "instance", req.Name, "err", err)
-			}
-		} else if err := waitCleanupOp(ctx, stopOp); err != nil {
+		if err := stopBuilderForCleanup(ctx, c, req.Name); err != nil {
 			slog.Error("error stopping builder instance", "instance", req.Name, "err", err)
 		}
 

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -2,6 +2,8 @@ package provision
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -104,4 +106,63 @@ func TestWaitCleanupOpIgnoresParentCancellation(t *testing.T) {
 
 	err := waitCleanupOp(parentCtx, op)
 	require.NoError(t, err)
+}
+
+func TestIsAlreadyStopped(t *testing.T) {
+	t.Run("matches the incus already-stopped status error", func(t *testing.T) {
+		err := api.StatusErrorf(http.StatusBadRequest, "The instance is already stopped")
+		assert.True(t, isAlreadyStopped(err))
+	})
+
+	t.Run("does not match other bad-request errors", func(t *testing.T) {
+		err := api.StatusErrorf(http.StatusBadRequest, "some other problem")
+		assert.False(t, isAlreadyStopped(err))
+	})
+
+	t.Run("does not match a plain error", func(t *testing.T) {
+		assert.False(t, isAlreadyStopped(errors.New("already stopped")))
+	})
+}
+
+func TestStopBuilderForCleanup(t *testing.T) {
+	alreadyStopped := api.StatusErrorf(http.StatusBadRequest, "The instance is already stopped")
+
+	t.Run("already stopped via WaitContext is not an error", func(t *testing.T) {
+		op := mocks.NewMockOperation(t)
+		op.On("WaitContext", mock.Anything).Return(alreadyStopped)
+
+		c := mocks.NewMockInstanceServer(t)
+		c.On("UpdateInstanceState", "builder", mock.Anything, "").Return(op, nil)
+
+		require.NoError(t, stopBuilderForCleanup(context.Background(), c, "builder"))
+	})
+
+	t.Run("already stopped synchronously is not an error", func(t *testing.T) {
+		c := mocks.NewMockInstanceServer(t)
+		c.On("UpdateInstanceState", "builder", mock.Anything, "").Return(nil, alreadyStopped)
+
+		require.NoError(t, stopBuilderForCleanup(context.Background(), c, "builder"))
+	})
+
+	t.Run("a genuine stop failure is returned", func(t *testing.T) {
+		op := mocks.NewMockOperation(t)
+		op.On("WaitContext", mock.Anything).Return(errors.New("boom"))
+
+		c := mocks.NewMockInstanceServer(t)
+		c.On("UpdateInstanceState", "builder", mock.Anything, "").Return(op, nil)
+
+		err := stopBuilderForCleanup(context.Background(), c, "builder")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("a stopped instance is stopped cleanly", func(t *testing.T) {
+		op := mocks.NewMockOperation(t)
+		op.On("WaitContext", mock.Anything).Return(nil)
+
+		c := mocks.NewMockInstanceServer(t)
+		c.On("UpdateInstanceState", "builder", mock.Anything, "").Return(op, nil)
+
+		require.NoError(t, stopBuilderForCleanup(context.Background(), c, "builder"))
+	})
 }


### PR DESCRIPTION
## Summary
Follow-up to #38, which did **not** actually fix the `error stopping builder instance ... "The instance is already stopped"` log.

**Root cause:** `UpdateInstanceState` is asynchronous. #38 only guarded the *synchronous* return value, but on the success path the "already stopped" condition comes back through the **operation's `WaitContext`** — which was still logged as an error. That's why the error kept appearing.

## Changes
- Extract `stopBuilderForCleanup`, which treats an "already stopped" response as a no-op whether it surfaces synchronously OR via the operation wait.
- Add `TestStopBuilderForCleanup` (covers both already-stopped paths + a genuine failure + a clean stop) and `TestIsAlreadyStopped`.

## Verification
- Confirmed the new `already stopped via WaitContext` test **fails** without the wait-path guard, then passes with it.
- `go build`, `go vet`, and the full `go test ./...` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)