### PR TITLE
fix: sync guest filesystem before stopping VM builder

### DIFF
--- a/provision/provision.go
+++ b/provision/provision.go
@@ -321,6 +321,28 @@ su - "${AGENT_USER}" -c "
 		}
 	}
 
+	// Flush the guest filesystem before stopping. For VM images the rootfs
+	// lives on a virtual block device and provisioning writes sit in the guest
+	// kernel's page cache; if we stop and publish without syncing, the snapshot
+	// can capture a half-written filesystem (e.g. a truncated AWS CLI install
+	// missing its /usr/local/bin/aws symlink). Containers write straight to the
+	// host FS so this is only strictly needed for VMs, but it's harmless either
+	// way.
+	syncReq := api.InstanceExecPost{
+		Command:   []string{"sync"},
+		WaitForWS: true,
+	}
+	syncOp, err := c.ExecInstance(req.Name, syncReq, &incus.InstanceExecArgs{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("error syncing guest filesystem: %w", err)
+	}
+	if err := checkExecExit(ctx, syncOp, "guest filesystem sync"); err != nil {
+		return err
+	}
+
 	// Stop the instance so it can published
 	slog.Info("stopping instance", "instance", i.Name)
 	op, err = c.UpdateInstanceState(req.Name, api.InstanceStatePut{


### PR DESCRIPTION
## Problem

For `--vm` builds, provisioning writes (e.g. an AWS CLI install in a custom script) land in the **guest kernel's page cache** and aren't guaranteed to be flushed to the virtual block device before we stop and publish the builder. The publish then snapshots a **half-written filesystem**.

Symptom: a provisioning script that installs the AWS CLI passes (`which aws` succeeds) during the build, but `aws` is missing in every instance launched from the published image. Inspecting a bad image showed a truncated install — `/usr/local/aws-cli` was 4MB / 995 files (vs. 267MB / 7517 complete) and `/usr/local/bin/aws` was never written to disk.

`which aws` passed during provisioning because it read the **live guest's cache**, where the symlink genuinely existed — but those dirty pages never reached the disk the publish snapshotted. Containers don't hit this (they write straight to the host FS), so it's VM-only and reproduces deterministically across machines.

## Fix

Exec `sync` in the guest immediately before stopping, so dirty pages are flushed to the virtual disk before the publish snapshot. Harmless for containers; required for VMs.

## Verification

Reproduced the exact failing scenario, then rebuilt with the fix and launched a VM from the published image:

| | before (no sync) | after (sync) |
|---|---|---|
| `which aws` | *(nothing)* | `/usr/local/bin/aws` |
| `aws --version` | not found | `aws-cli/2.35.5` |
| files in aws-cli | 995 (truncated) | 7517 |
| size | 4 MB | 267 MB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)