### PR TITLE
fix: prevent publish-finalize deadlock leaving image unaliased

### DIFF
--- a/provision/provision.go
+++ b/provision/provision.go
@@ -379,6 +379,50 @@ su - "${AGENT_USER}" -c "
 		return err
 	}
 
+	joinFinalizer := startFinalizeSpinner(ctx, op)
+
+	if err = op.WaitContext(ctx); err != nil {
+		joinFinalizer()
+		return err
+	}
+	joinFinalizer()
+
+	// Grab the fingerprint
+	fingerprint, ok := op.Get().Metadata["fingerprint"].(string)
+	if !ok {
+		return fmt.Errorf("error getting fingerprint for new image")
+	}
+
+	// Before aliasing the image, delete any existing aliases
+	_, _, err = c.GetImageAlias(conf.TargetAlias)
+	if err != nil {
+		if !api.StatusErrorCheck(err, http.StatusNotFound) {
+			return err
+		}
+	} else {
+		if err = c.DeleteImageAlias(conf.TargetAlias); err != nil {
+			return fmt.Errorf("error deleting the alias from old image: %w", err)
+		}
+	}
+
+	// Now create the alias for the image
+	ciReq := api.ImageAliasesPost{}
+	ciReq.Name = conf.TargetAlias
+	ciReq.Type = instanceTypeStr(conf.VM)
+	ciReq.Target = fingerprint
+
+	return c.CreateImageAlias(ciReq)
+
+}
+
+// startFinalizeSpinner renders the image-publish progress bar and, once the
+// data-transfer phase completes, a "finalizing image" spinner for the
+// server-side finalization that would otherwise look like a hang at 100%.
+//
+// It returns a join function that stops the spinner goroutine and waits for it
+// to exit. Callers must invoke the join exactly once after op.WaitContext
+// returns (on both the error and success paths).
+func startFinalizeSpinner(ctx context.Context, op incus.Operation) func() {
 	p := progressbar.NewOptions64(100,
 		progressbar.OptionSetDescription("publishing progress"),
 		progressbar.OptionSetWriter(os.Stderr),
@@ -387,11 +431,6 @@ su - "${AGENT_USER}" -c "
 			fmt.Fprint(os.Stderr, "\n")
 		}),
 	)
-	defer func() {
-		if err := p.Close(); err != nil {
-			slog.Error("error closing progress bar", "err", err)
-		}
-	}()
 
 	// atDataDone is closed once the data-transfer phase reaches 100%. After
 	// that, the server still spends time finalizing (compressing and storing)
@@ -441,8 +480,16 @@ su - "${AGENT_USER}" -c "
 	go func() {
 		defer close(finalizeDone)
 
+		// Wait for the data-transfer phase to hit 100% before showing the
+		// finalize spinner. finalizeStop must be an arm here too: the progress
+		// handler is best-effort and may never deliver a 100% event (e.g. a
+		// fast or coalesced publish), so without this case the goroutine would
+		// block on atDataDone forever and the close(finalizeStop)/<-finalizeDone
+		// join below would deadlock.
 		select {
 		case <-atDataDone:
+		case <-finalizeStop:
+			return
 		case <-ctx.Done():
 			return
 		}
@@ -476,40 +523,21 @@ su - "${AGENT_USER}" -c "
 		}
 	}()
 
-	if err = op.WaitContext(ctx); err != nil {
+	// The returned join stops the spinner goroutine and waits for it to exit.
+	// The wait is also guarded by ctx.Done() so a Ctrl-C (which cancels ctx) can
+	// always break the main goroutine out of the join, even if the spinner
+	// goroutine were wedged for some unforeseen reason — belt and suspenders on
+	// top of the finalizeStop arms inside the goroutine itself.
+	return func() {
 		close(finalizeStop)
-		<-finalizeDone
-		return err
-	}
-	close(finalizeStop)
-	<-finalizeDone
-
-	// Grab the fingerprint
-	fingerprint, ok := op.Get().Metadata["fingerprint"].(string)
-	if !ok {
-		return fmt.Errorf("error getting fingerprint for new image")
-	}
-
-	// Before aliasing the image, delete any existing aliases
-	_, _, err = c.GetImageAlias(conf.TargetAlias)
-	if err != nil {
-		if !api.StatusErrorCheck(err, http.StatusNotFound) {
-			return err
+		select {
+		case <-finalizeDone:
+		case <-ctx.Done():
 		}
-	} else {
-		if err = c.DeleteImageAlias(conf.TargetAlias); err != nil {
-			return fmt.Errorf("error deleting the alias from old image: %w", err)
+		if err := p.Close(); err != nil {
+			slog.Error("error closing progress bar", "err", err)
 		}
 	}
-
-	// Now create the alias for the image
-	ciReq := api.ImageAliasesPost{}
-	ciReq.Name = conf.TargetAlias
-	ciReq.Type = instanceTypeStr(conf.VM)
-	ciReq.Target = fingerprint
-
-	return c.CreateImageAlias(ciReq)
-
 }
 
 // getAgentDownloadURL fetches the latest Azure Pipelines agent release and returns

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -108,6 +108,73 @@ func TestWaitCleanupOpIgnoresParentCancellation(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestStartFinalizeSpinnerJoinDoesNotDeadlock is a regression test for the
+// publish-finalize deadlock: if the publish operation never delivers a 100%
+// progress event (a best-effort callback), the spinner goroutine used to block
+// forever on atDataDone, so the join (close(finalizeStop); <-finalizeDone) hung
+// and provision never returned — leaving the image published but never aliased.
+//
+// The mock Operation here registers a handler but never invokes it, so no 100%
+// event is ever delivered. The join must still return promptly.
+func TestStartFinalizeSpinnerJoinDoesNotDeadlock(t *testing.T) {
+	op := mocks.NewMockOperation(t)
+	// Handler is registered but intentionally never called: simulate a publish
+	// where the 100% progress event is missing/coalesced.
+	op.On("AddHandler", mock.Anything).Return(nil, nil)
+
+	join := startFinalizeSpinner(context.Background(), op)
+
+	done := make(chan struct{})
+	go func() {
+		join()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startFinalizeSpinner join deadlocked when no 100% progress event was delivered")
+	}
+}
+
+// TestStartFinalizeSpinnerJoinUnblocksOnCancel verifies the belt-and-suspenders
+// guard: even if the spinner goroutine were wedged, a canceled context must let
+// the join return so a Ctrl-C is never swallowed. Here the data-transfer phase
+// has "completed" so the spinner goroutine is running its ticker loop; canceling
+// the context before joining must still unblock the caller.
+func TestStartFinalizeSpinnerJoinUnblocksOnCancel(t *testing.T) {
+	op := mocks.NewMockOperation(t)
+
+	var handler func(api.Operation)
+	op.On("AddHandler", mock.Anything).Return(nil, nil).Run(func(args mock.Arguments) {
+		handler = args.Get(0).(func(api.Operation))
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	join := startFinalizeSpinner(ctx, op)
+
+	// Drive the data-transfer phase to 100% so the spinner goroutine advances
+	// into its ticker loop, then cancel to exercise the join's ctx.Done() arm.
+	require.NotNil(t, handler)
+	handler(api.Operation{Metadata: map[string]any{
+		"progress": map[string]any{"percent": "100"},
+	}})
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		join()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startFinalizeSpinner join did not unblock on context cancellation")
+	}
+}
+
 func TestIsAlreadyStopped(t *testing.T) {
 	t.Run("matches the incus already-stopped status error", func(t *testing.T) {
 		err := api.StatusErrorf(http.StatusBadRequest, "The instance is already stopped")


### PR DESCRIPTION
## Problem

While provisioning a new host (`dedi-incus-zfs-2`), the Ansible `Provision base image` task hung forever. Investigation on the box showed:

- The image **was published** (2.1 GiB, finalized) but had **no alias** attached.
- The `provision` process was parked in a Go futex across all threads with **no incus operations active and no socket connections** — it wasn't waiting on incus, it was waiting on an internal channel that never closed.
- SIGINT (Ctrl-C) couldn't kill it; only SIGKILL did.

## Root cause

The publish path starts a goroutine that shows a "finalizing image" spinner once the data-transfer phase hits 100%. That goroutine blocks on `atDataDone`, which is only closed when the progress handler observes a `percent == 100` event. The publish progress callback is **best-effort** — a fast or coalesced publish can complete without ever delivering a 100% event. When that happens:

1. The goroutine parks on `<-atDataDone` forever.
2. The main goroutine reaches `close(finalizeStop); <-finalizeDone` — but the goroutine isn't selecting on `finalizeStop` yet, so `finalizeDone` never closes and the main goroutine **deadlocks**.

This happens *after* `CreateImage` succeeds but *before* `CreateImageAlias`, which is exactly why the image is published but unaliased, and why the Ansible `command` task waits forever.

## Fix (belt-and-suspenders)

1. Add a `finalizeStop` arm to the goroutine's **first** select, so `close(finalizeStop)` always unblocks it regardless of whether `atDataDone` fired. *(This alone fixes the deadlock.)*
2. Guard the join's `<-finalizeDone` with `ctx.Done()`, so a Ctrl-C can always break the main goroutine out of the join even if the goroutine were wedged for any other reason.

The spinner logic is extracted into `startFinalizeSpinner` (returning a join closure) so the join is unit-testable.

## Tests

- `TestStartFinalizeSpinnerJoinDoesNotDeadlock` — simulates a publish where no 100% event is delivered; the join must return promptly. **Verified this test fails (5s timeout) with fix #1 reverted.**
- `TestStartFinalizeSpinnerJoinUnblocksOnCancel` — verifies the ctx.Done() guard.

Full suite + `go vet` + `golangci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)